### PR TITLE
Update CI to update checkout to v4 and remove Sonar Cloud analysis

### DIFF
--- a/.github/workflows/doxygen-release.yml
+++ b/.github/workflows/doxygen-release.yml
@@ -13,7 +13,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install cmake libfftw3-dev libopenmpi-dev openmpi-bin libpetsc-real3.12-dbg libblas-dev liblapack-dev ninja-build doxygen graphviz
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Cmake Configure
       run: cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DPETSC_DIR=/usr/lib/petscdir/petsc3.12/x86_64-linux-gnu-real-debug/ -GNinja .
     - name: Generate Doxygen

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install cmake libfftw3-dev libopenmpi-dev openmpi-bin libpetsc-real3.12-dbg libblas-dev liblapack-dev ninja-build doxygen graphviz
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Cmake Configure
       run: cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DPETSC_DIR=/usr/lib/petscdir/petsc3.12/x86_64-linux-gnu-real-debug/ -GNinja .
     - name: Generate Doxygen

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -43,7 +43,7 @@ jobs:
         restore-keys: |
           ${{ matrix.name }}-ccache-
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -28,16 +28,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install ${{ matrix.ubuntu_packages }} ninja-build ccache
         
-    - name: Install Sonar Scanner
-      if: ${{ matrix.analyze }}
-      env:
-        SONAR_SCANNER_URL: https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip
-      run: |
-        wget --quiet $SONAR_SCANNER_URL
-        unzip sonar-scanner-*-linux.zip
-        mv sonar-scanner-*-linux $HOME/sonar-scanner-linux
-        echo $HOME/sonar-scanner-linux/bin >> $GITHUB_PATH
-
     - name: Prepare cache timestamp
       id: cache_timestamp
       shell: cmake -P {0}
@@ -52,15 +42,6 @@ jobs:
         key: ${{ matrix.name }}-ccache-${{ steps.cache_timestamp.outputs.timestamp }}
         restore-keys: |
           ${{ matrix.name }}-ccache-
-
-    - name: sonar-scanner cache files
-      if: ${{ matrix.analyze }}
-      uses: actions/cache@v2
-      with:
-        path: ~/.sonar/cache
-        key: ${{ matrix.name }}-sonar-scanner-${{ steps.cache_timestamp.outputs.timestamp }}
-        restore-keys: |
-          ${{ matrix.name }}-sonar-scanner-
 
     - uses: actions/checkout@v2
       with:
@@ -92,22 +73,3 @@ jobs:
     - name: Upload to codecov.io
       if: ${{ matrix.analyze }}
       run: bash <(curl -s https://codecov.io/bash)
-
-    - name: Run sonar-scanner
-      if: ${{ matrix.analyze }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: |
-        sonar-scanner \
-        -Dsonar.cfamily.llvm-cov.reportPath=coverage.txt \
-        -Dsonar.projectKey=thunderegg \
-        -Dsonar.organization=thunderegg \
-        -Dsonar.sources=src \
-        -Dsonar.exclusions=src/ThunderEgg/Experimental/**/*,src/ThunderEgg/tpl/**/* \
-        -Dsonar.cpd.exclusions=src/ThunderEgg/VarPoisson/**/*,src/ThunderEgg/Poisson/**/* \
-        -Dsonar.cfamily.compile-commands=out/build/${{ matrix.preset }}/compile_commands.json \
-        -Dsonar.host.url=https://sonarcloud.io \
-        -Dsonar.cfamily.threads=2 \
-        -Dsonar.cfamily.cache.enabled=true \
-        -Dsonar.cfamily.cache.path=$HOME/.sonar/cache


### PR DESCRIPTION
Update CI to update checkout action to v4 to remove warnings, and remove Sonar Cloud analysis step since this is now done from Sonar Cloud automatically.