### PR TITLE
Fix memory leak in Communicator

### DIFF
--- a/src/ThunderEgg/Communicator.cpp
+++ b/src/ThunderEgg/Communicator.cpp
@@ -47,6 +47,7 @@ Communicator::Communicator(MPI_Comm comm)
     if (*comm_ptr != MPI_COMM_NULL && !finalized) {
       MPI_Comm_free(comm_ptr);
     }
+    delete comm_ptr;
   });
 }
 


### PR DESCRIPTION
free the pointer to the MPI_Comm