### PR TITLE
Update CI to use latest version cache action

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -36,7 +36,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
 
     - name: ccache cache files
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.ccache
         key: ${{ matrix.name }}-ccache-${{ steps.cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -30,10 +30,8 @@ jobs:
         
     - name: Prepare cache timestamp
       id: cache_timestamp
-      shell: cmake -P {0}
       run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
+        echo "timestamp=`date "+%Y-%m-%d-%H:%M:%S"`" >> $GITHUB_OUTPUT
 
     - name: ccache cache files
       uses: actions/cache@v3


### PR DESCRIPTION
Update CI to use latest version cache action, and update timestamp to use output file